### PR TITLE
Embrace async\await

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "chrome-remote-interface": "^0.19.0",
-    "minimist": "^1.2.0"
+    "chrome-remote-interface": "^0.23.0",
+    "delay": "^2.0.0",
+    "minimist": "^1.2.0",
+    "mz": "^2.6.0"
   }
 }


### PR DESCRIPTION
Thanks for this tool.
Very helpful.

Right now the code mixes callbacks, promises, and async\await. And it's a bit confusing to follow IMHO.
This PR standardizes the code on async\await.

To support this, I needed to update to the latest version of `chrome-remote-interface` which returns a promise for the `CDP()` constructor and `Page.loadEventFired()`.  
Also used a native promise alternative for the `fs` module ([github.com/normalize/mz](https://github.com/normalize/mz)) and for `setTimeout` ([github.com/sindresorhus/delay](https://github.com/sindresorhus/delay)).

Thanks.