### PR TITLE
When fullPage option is settled, take the specified delay before setting the visible size.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ async function init() {
 
     // Wait for page load event to take screenshot
     await Page.loadEventFired();
+
+    await timeout(delay);
+
     // If the `full` CLI option was passed, we need to measure the height of
     // the rendered page and use Emulation.setVisibleSize
     if (fullPage) {
@@ -67,7 +70,6 @@ async function init() {
       await Emulation.forceViewport({x: 0, y: 0, scale: 1});
     }
 
-    await timeout(delay);
     const screenshot = await Page.captureScreenshot({format});
     const buffer = new Buffer(screenshot.data, 'base64');
     await file.writeFile(output, buffer, 'base64');


### PR DESCRIPTION
I want to capture whole page, but often the result image lacks the bottom area.
The capturing area was determined before waiting.
I changed to take the delay, determine the capturing area, and capture.