### PR TITLE
make index.js and chrome run within a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:8.2.1
+
+# Install chrome
+RUN apt-get update
+RUN apt-get install -y libxss1 libappindicator1 libindicator7
+RUN wget --quiet https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome*.deb; exit 0
+## above might show "errors", fixed by next line
+RUN apt-get install -y -f
+
+# Prepare app directory
+RUN mkdir -p /usr/src/app
+ADD . /usr/src/app
+
+# Install dependencies
+WORKDIR /usr/src/app
+RUN npm install
+
+# Prepare output area
+RUN mkdir -p /var/output/
+
+# Make executable
+RUN chmod +x ./run.sh
+
+ENTRYPOINT [ "./run.sh" ]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The screenshot will then be available as *output.png*
 
 ### Setup on OSX
 
-Headless Chrome is still highly unstable on OSX (see issue [#1](https://github.com/schnerd/chrome-headless-screenshots/issues/1)). At this point in time I recommend just running chrome & node in docker or vagrant (Dokerfile/Vagrantfile pull requests welcome).
+Headless Chrome is still highly unstable on OSX (see issue [#1](https://github.com/schnerd/chrome-headless-screenshots/issues/1)). At this point in time I recommend just running chrome & node in docker or vagrant (Vagrantfile pull requests welcome).
 
 If you must run it natively, use the following commands:
 ```
@@ -44,6 +44,26 @@ node index.js --url="http://www.eff.org"
 ```
 
 If screenshots on Mac do not appear to be working, please report an issue on [ChromeDevTools/devtools-protocol](https://github.com/ChromeDevTools/devtools-protocol), [cyrus-and/chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface), or chromium itself.
+
+### Setup on Docker
+
+Build image:
+```
+docker build -t chrome-headless-screenshots-app .
+```
+
+Run container, saving output in local dir in the file output.png:
+```
+docker run -it -v ${PWD}:/var/output/ --rm chrome-headless-screenshots-app --url="http://www.eff.org"
+```
+
+Note that for newer versions of docker, you may see an error like:
+
+```
+libudev: udev_has_devtmpfs: name_to_handle_at on /dev: Operation not permitted
+```
+
+This appears to be harmless, and is caused by Chrome attempting to use /dev/shm for caching, which is more restricted in later versions of docker. If you really want to get rid of the warning then you can either dig a bit further to put together a seccomp file for chrome (see https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile for a start), or use `--security-opt seccomp:unconfined` but note that this is *not recommended* ("seccomp is instrumental for running Docker containers with least privilege. It is not recommended to change the default seccomp profile."). For now, we recommend just living with the warning.
 
 ### Other Resources
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ let viewportHeight = argv.viewportHeight || 900;
 const delay = argv.delay || 0;
 const userAgent = argv.userAgent;
 const fullPage = argv.full;
+const outputDir = argv.outputDir || './';
 const output = argv.output || `output.${format === 'png' ? 'png' : 'jpg'}`;
 
 init();
@@ -90,7 +91,8 @@ async function init() {
     });
 
     const buffer = new Buffer(screenshot.data, 'base64');
-    await file.writeFile(output, buffer, 'base64');
+    const path = `${outputDir + output}`;
+    await file.writeFile(path, buffer, 'base64');
     console.log('Screenshot saved');
     client.close();
   } catch (err) {

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+google-chrome --headless --hide-scrollbars --remote-debugging-port=9222 --no-sandbox --disable-gpu &
+
+# need to sleep to allow chrome time to start
+sleep 1s
+
+node index.js --outputDir=/var/output/ "$@"


### PR DESCRIPTION
- needed to change index.js to allow output to be saved in a
separate directory, so that this directory could be shared via
a volume