### PR TITLE
Fix for Emulation.forceViewport is not a function on Chrome 60.0.3112.90

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ async function init() {
     }
 
     // Set up viewport resolution, etc.
-    const deviceMetrics = {
+    let deviceMetrics = {
       width: viewportWidth,
       height: viewportHeight,
       deviceScaleFactor: 0,
@@ -64,7 +64,7 @@ async function init() {
     await timeout(delay);
 
     // If the `full` CLI option was passed, we need to measure the height of
-    // the rendered page and use Emulation.setVisibleSize
+    // the rendered page and call setDeviceMetricsOverride + setVisibleSize again
     if (fullPage) {
       const {root: {nodeId: documentNodeId}} = await DOM.getDocument();
       const {nodeId: bodyNodeId} = await DOM.querySelector({
@@ -72,12 +72,11 @@ async function init() {
         nodeId: documentNodeId,
       });
       const {model} = await DOM.getBoxModel({nodeId: bodyNodeId});
-      viewportHeight = model.height;
 
+      viewportHeight = model.height;
+      deviceMetrics.height = viewportHeight;
+      await Emulation.setDeviceMetricsOverride(deviceMetrics);
       await Emulation.setVisibleSize({width: viewportWidth, height: viewportHeight});
-      // This forceViewport call ensures that content outside the viewport is
-      // rendered, otherwise it shows up as grey. Possibly a bug?
-      await Emulation.forceViewport({x: 0, y: 0, scale: 1});
     }
 
     const screenshot = await Page.captureScreenshot({


### PR DESCRIPTION
**Why**
While testing the fullPage (--full=true) feature the script returned an error: Exception while taking screenshot: TypeError: Emulation.forceViewport is not a function. Check [this](https://github.com/cyrus-and/chrome-remote-interface/issues/203#issuecomment-316131654) link for a comment from paulirish about it.

This pull request makes the fullPage option work again.

**Versions**
Chrome version: Version 60.0.3112.90 (Official Build) (64-bit)
macOS version: 10.12.6