### PR TITLE
wait until the debug port opens

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 google-chrome --headless --hide-scrollbars --remote-debugging-port=9222 --no-sandbox --disable-gpu &
 
-# need to sleep to allow chrome time to start
-sleep 1s
+# wait until the debug port opens
+while : ; do
+  set +e
+  (echo > /dev/tcp/127.0.0.1/9222) >/dev/null 2>&1
+  [[ $? -eq 0 ]] && break
+  set -e
+  sleep 1
+done
 
 node index.js --outputDir=/var/output/ "$@"


### PR DESCRIPTION
On my machine it takes more than 1 second for Chrome to be ready.
This way we can wait until Chrome actually starts listening on the port (the same way [vishnubob/wait-for-it](https://github.com/vishnubob/wait-for-it) does).